### PR TITLE
Enable filename_callback to receive a key

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,17 @@ photo.image.name #=> filename
 
 # Attach example
 
-Two image file upload to backend example.
-defined method by `tori` method can define a key name for each by block.
+Example of uploadng two image files to backend.
+filename can be defined for each key if pass a block to `tori`.
 
 ```ruby
 class Photo < ActiveRecord::Base
-  tori :original_image do |model|
-    "#{model.class}/original/#{model.original_filename}"
+  tori :original_image do |model, key|
+    "#{model.class}/#{key}/#{model.original_filename}"
   end
 
-  tori :striped_image do |model|
-    "#{model.class}/striped/#{model.striped_filename}"
+  tori :striped_image do |model, key|
+    "#{model.class}/#{key}/#{model.striped_filename}"
   end
 end
 
@@ -124,7 +124,7 @@ require 'tori/backend/s3'
 Tori.config.backend = Tori::Backend::S3.new(bucket: 'tori_bucket')
 
 # Filename decided by model.class.name,id and hidden words.
-Tori.config.filename_callback do |model|
+Tori.config.filename_callback do |model, key|
   "#{model.class.name}/#{Digest::SHA1.hexdigest "#{ENV["TORI_MAGICKWORD"]}/#{model.id}"}"
 end
 ```

--- a/lib/tori.rb
+++ b/lib/tori.rb
@@ -26,7 +26,7 @@ module Tori
 
         # Filename hashing method
         #   It's call when decide filename hash.
-        config.filename_callback do |model|
+        config.filename_callback do |model, key|
           Digest::SHA1.hexdigest "#{model.class.name}/#{model.id}"
         end
       end

--- a/lib/tori/define.rb
+++ b/lib/tori/define.rb
@@ -5,11 +5,11 @@ module Tori
 
       define_method(name) do
         ivar = instance_variable_get name_ivar
-        ivar || instance_variable_set(name_ivar, File.new(self, &block))
+        ivar || instance_variable_set(name_ivar, File.new(self, name, &block))
       end
 
       define_method("#{name}=") do |uploader|
-        file = File.new(self, from: uploader, &block)
+        file = File.new(self, name, from: uploader, &block)
         instance_variable_set name_ivar, file
       end
     end

--- a/lib/tori/file.rb
+++ b/lib/tori/file.rb
@@ -1,21 +1,29 @@
 module Tori
   class File
-    def initialize(model, from: nil, &block)
+    def initialize(model, key, from: nil, &block)
       @model = model
+      @key   = key
+
       if from.respond_to?(:read) and from.respond_to?(:rewind)
         from.rewind
         @from = from.read
       else
         @from = from
       end
+
       @filename_callback = block
     end
 
     def name
       if @filename_callback
-        @filename_callback.call(@model)
+        if @filename_callback.lambda? && @filename_callback.arity == 1
+          warn '[DEPRECATION] filename_callback should be received two arguments.'
+          @filename_callback.call(@model)
+        else
+          @filename_callback.call(@model, @key)
+        end
       else
-        Tori.config.filename_callback.call(@model)
+        Tori.config.filename_callback.call(@model, @key)
       end
     end
     alias to_s name

--- a/test/test_tori_file.rb
+++ b/test/test_tori_file.rb
@@ -24,29 +24,29 @@ class TestToriFile < Test::Unit::TestCase
   end
 
   test "#initialize" do
-    assert_instance_of Tori::File, Tori::File.new(nil)
-    assert_instance_of Tori::File, Tori::File.new(nil, from: nil)
-    assert_instance_of Tori::File, Tori::File.new(nil, from: nil) { }
+    assert_instance_of Tori::File, Tori::File.new(nil, nil)
+    assert_instance_of Tori::File, Tori::File.new(nil, nil, from: nil)
+    assert_instance_of Tori::File, Tori::File.new(nil, nil, from: nil) { }
   end
 
   test "#name" do
-    assert { "test" == Tori::File.new("test").name }
-    assert { "String/test/sub" == Tori::File.new("test"){ |m| "#{m.class}/#{m}/sub"}.name }
+    assert { "test" == Tori::File.new("test", nil).name }
+    assert { "String/test/sub" == Tori::File.new("test", nil){ |m| "#{m.class}/#{m}/sub"}.name }
   end
 
   test "#exist?" do
-    assert { true == Tori::File.new(__FILE__).exist? }
-    assert { false == Tori::File.new("nothing_file").exist? }
+    assert { true == Tori::File.new(__FILE__, nil).exist? }
+    assert { false == Tori::File.new("nothing_file", nil).exist? }
   end
 
   test "#from?" do
-    assert { false == Tori::File.new(__FILE__).from? }
-    assert { true == Tori::File.new(__FILE__, from: From.new).from? }
+    assert { false == Tori::File.new(__FILE__, nil).from? }
+    assert { true == Tori::File.new(__FILE__, nil, from: From.new).from? }
   end
 
   test "write" do
     assert { false == File.exist?("test/tmp/copy") }
-    Tori::File.new("copy", from: From.new).write
+    Tori::File.new("copy", nil, from: From.new).write
     assert { true == File.exist?("test/tmp/copy") }
   end
 
@@ -56,7 +56,7 @@ class TestToriFile < Test::Unit::TestCase
     Tempfile.create("tempfile") do |f|
       path = f.path
       f.write("should be match ;)")
-      tori_file = Tori::File.new("tempfile", from: f)
+      tori_file = Tori::File.new("tempfile", nil, from: f)
     end
     tori_file.write
     assert { true == File.exist?("test/tmp/tempfile") }
@@ -66,7 +66,7 @@ class TestToriFile < Test::Unit::TestCase
   end
 
   test "#method_missing" do
-    assert { true == Tori::File.new(nil).respond_to?(:read) }
-    assert_raise(NameError) { Tori::File.new(nil).undefined }
+    assert { true == Tori::File.new(nil, nil).respond_to?(:read) }
+    assert_raise(NameError) { Tori::File.new(nil, nil).undefined }
   end
 end


### PR DESCRIPTION
I think this code ins't DRY.

```ruby
class Model < AR::Base
  tori :key1 { |model| "#{model.class}/key1/#{model.id}" }
  tori :key2 { |model| "#{model.class}/key2/#{model.id}" }
end
```

It is common to create directory for each key, so filename_callback should be received a key.