### PR TITLE
Add attr_reader for @from in Tori::File.

### DIFF
--- a/lib/tori/file.rb
+++ b/lib/tori/file.rb
@@ -28,6 +28,7 @@ module Tori
     end
     alias to_s name
 
+    attr_reader :from
     def from?
       !@from.nil?
     end

--- a/test/test_tori_file.rb
+++ b/test/test_tori_file.rb
@@ -42,6 +42,10 @@ class TestToriFile < Test::Unit::TestCase
     assert { false == Tori::File.new("nothing_file").exist? }
   end
 
+  test "#from" do
+    assert { __FILE__ == Tori::File.new(__FILE__, from: From.new).from }
+  end
+
   test "#from?" do
     assert { false == Tori::File.new(__FILE__).from? }
     assert { true == Tori::File.new(__FILE__, from: From.new).from? }


### PR DESCRIPTION
Add attr_reader for @from in Tori::File because in some cases updated data will be required to read without backend access.

For example: 

```rb
class Hoge < ActiveRecord::Base
  tori :file

  after_save do
    if file.from?
      # upload file
      file.write
      # processing about from data without backend access
      update_column(:size, file.from.size)
    end
  end
end
```