### PR TITLE
Drop support of eol ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.1.8
   - 2.2.4
   - 2.3.0
 notifications:


### PR DESCRIPTION
All support of the Ruby 2.1 series has ended

ref https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/